### PR TITLE
Don't run shellcheck on fish files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,11 @@ interface WritableStreamDefaultWriter<W = any> {
 
 class IssuesProvider {
   provideIssues(editor: TextEditor): AssistantArray<Issue> {
+    // Fish shell is not supported by ShellCheck
+    if (editor.document.uri.endsWith(".fish")) {
+      return [];
+    }
+
     console.info("validating: ", editor.document.uri);
 
     const documentLength = editor.document.length;


### PR DESCRIPTION
Currently, having the ShellCheck extension active means that working on Fish shell script will raise errors:

![Capture d’écran 2023-01-08 à 16 55 32](https://user-images.githubusercontent.com/1041337/211206352-c9adf593-3314-49f6-9872-39bddaa90be0.png)

This is because the `.fish` files are detected as using the `shell` syntax, so this extension is triggered. But unfortunately ShellCheck does not support Fish.

The proposed fix is to identify any Fish script (by looking at the file extension) before running ShellCheck.