### PR TITLE
Run shellcheck from the project root

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ class IssuesProvider {
     const process: Promise<string> = new Promise((resolve) => {
       const process = new Process("shellcheck", {
         shell: true,
+        cwd: nova.workspace.path as string,
         args: ["--format", "json", "-"],
       });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,11 +22,18 @@ class IssuesProvider {
     );
 
     const process: Promise<string> = new Promise((resolve) => {
-      const process = new Process("shellcheck", {
+      type ProcessOptions = { args?: string[]; cwd?: string; shell: true };
+
+      const options: ProcessOptions = {
         shell: true,
-        cwd: nova.workspace.path as string,
         args: ["--format", "json", "-"],
-      });
+      };
+
+      if (nova.workspace.path) {
+        options["cwd"] = nova.workspace.path;
+      }
+
+      const process = new Process("shellcheck", options);
 
       let buffer = "";
       process.onStdout(function (line) {


### PR DESCRIPTION
This allows project specific `shellcheck` settings to be applied.

It took me quite a while to figure out why this plugin wasn't using the settings in the `.shellcheckrc` at the root of the repository. It's because `shellcheck` walks up the directory path until it finds the first `.shellcheckrc`. The default directory where the `shellcheck` process is executed is `~/Library/Application Support/Nova/Extensions/[extension directory]`.